### PR TITLE
add ERC4246 methods for depositing/withdrawing from the wrapper

### DIFF
--- a/contracts/StaticUsdPlusToken.sol
+++ b/contracts/StaticUsdPlusToken.sol
@@ -15,14 +15,29 @@ contract StaticUsdPlusToken is IStaticUsdPlusToken, ERC20 {
         _mainToken = UsdPlusToken(mainTokenAddress);
     }
 
+    event Deposit(address indexed from, address indexed to, uint256 value);
+
+    event Withdraw(address indexed from, address indexed to, uint256 value);
+
     ///@inheritdoc ERC20
     function decimals() public view override(ERC20, IERC20Metadata) returns (uint8) {
         return 6;
     }
 
+    /**
+      @notice Deposit a specific amount of underlying tokens.
+      @param amount The amount of the underlying token to deposit.
+      @param to The address to receive shares corresponding to the deposit
+      @return shares The shares in the vault credited to `to`
+     */
+    function deposit(uint256 amount, address to) public returns (uint256) {
+      emit Deposit(msg.sender, to, amount);
+
+      return wrap(to, amount);
+    }
 
     ///@inheritdoc IStaticUsdPlusToken
-    function wrap(address recipient, uint256 amount) external override returns (uint256){
+    function wrap(address recipient, uint256 amount) public override returns (uint256){
         require(recipient != address(0), "Zero address for recipient not allowed");
         require(amount != 0, "Zero amount not allowed");
 
@@ -34,8 +49,22 @@ contract StaticUsdPlusToken is IStaticUsdPlusToken, ERC20 {
         return mintAmount;
     }
 
+    /**
+      @notice Withdraw a specific amount of underlying tokens.
+      @param amount The amount of the underlying token to withdraw.
+      @param to The address to receive underlying corresponding to the withdrawal.
+      @param from The address to burn shares from corresponding to the withdrawal.
+      @return shares The shares in the vault burned from sender
+     */
+    function withdraw(uint256 amount, address to, address from) public returns (uint256) {
+      require(msg.sender == from);
+      emit Withdraw(msg.sender, to, amount);
+
+      return unwrap(receiver, assets);
+    }
+
     ///@inheritdoc IStaticUsdPlusToken
-    function unwrap(address recipient, uint256 amount) external override returns (uint256, uint256){
+    function unwrap(address recipient, uint256 amount) public override returns (uint256, uint256){
         require(recipient != address(0), "Zero address for recipient not allowed");
         require(amount != 0, "Zero amount not allowed");
 


### PR DESCRIPTION
This adds ERC4626 methods to deposit/withdraw from the wrapper to simplify the PR adding ERC4626 support in Balancer boosted pools https://github.com/balancer-labs/balancer-v2-monorepo/pull/1120/files

I was unsure whether we should use the methods in the reference implementation
https://github.com/fei-protocol/ERC4626/blob/main/src/interfaces/IERC4626.sol

or the EIP
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4626.md

They differ in that `withdraw` has a from parameter in the reference implementation

I suspect we can hammer down a spec very soon with @JoeySantoro's help